### PR TITLE
Fixes and updates to compliance structure

### DIFF
--- a/R/Intervention_functions.R
+++ b/R/Intervention_functions.R
@@ -147,7 +147,7 @@ editPTreat <- function(pTreat, cov, rho) {
   newPTreats <- sort(rbeta(N, alpha, beta))
 
   # Rank the original pTreat values to get indices for sorting
-  indices <- rank(pTreat)
+  indices <- sort(pTreat, index.return=TRUE)$ix
 
   # Assign the values from newPTreats to the appropriate places in pTreat vector
   pTreat <- newPTreats[indices]

--- a/R/Model_wrappers.R
+++ b/R/Model_wrappers.R
@@ -73,8 +73,7 @@ ep.equi.sim <- function(time.its,
                         correlated_compliance = "NO",
                         comp.correlation,
                         treat.switch = NA,
-                        treat.type = NA,
-                        treat.switch.start=NA)
+                        treat.type = NA)
 
 
 {


### PR DESCRIPTION
- Fixed an issue where rank didn't properly sort the pTreat, causing more people to be treated than expected when coverage/correlation changed.
- Added outputs to the R file including PNC, and a year calculation
- Removed explicit declerations of DT (I.e using 1/366 or 366), and replaced them with DT instead, allowing for DT to be changed easily.
