### PR TITLE
Removing hard set population of 440

### DIFF
--- a/R/Model_wrappers.R
+++ b/R/Model_wrappers.R
@@ -47,7 +47,7 @@
 
 ep.equi.sim <- function(time.its,
                         ABR,
-                        N.in,
+                        N.in=440,
                         treat.int,
                         treat.timing,
                         treat.prob,
@@ -141,7 +141,7 @@ ep.equi.sim <- function(time.its,
   g = 0.0096
   a.v = 0.39
   real.max.age = 80 #no humans live longer than 80 years
-  N = 440 #human population size
+  N = N.in #human population size
   mean.age = 50 #mean human age (before truncation)
   int.L3 = 0.03; int.L2 = 0.03; int.L1 = 0.03
   lambda.zero = 0.33 # (matt:) per-capita rate that female worms lose their fertility (W_FF) & return to non-fertile state (W_FN)


### PR DESCRIPTION
The population of the model was hard coded to be 440, even though we allow a parameter to set the population size (N.in). This fix will set the population size to be whatever is passed in, or defaulted to 440 if nothing is passed in.