### PR TITLE
Adding l3 prevalence in blackflies

### DIFF
--- a/R/Model_wrappers.R
+++ b/R/Model_wrappers.R
@@ -71,6 +71,8 @@ ep.equi.sim <- function(time.its,
                         c.h.in=0.005,
                         gam.dis.in=0.3,
                         Q = 1.2,
+                        k0_in = 0.0054, # 95% CI = (0.0012, 0.0097)
+                        k1_in = 0.1459, # 95% CI = (0.0548, 0.237)
                         kM.const.toggle = FALSE,
                         output_age_groups = list(c(0, 5), c(5, 10), c(10, 15), c(15, 20), c(20, 30), c(30, 50), c(50, 81)),
                         run_equilibrium,
@@ -329,6 +331,7 @@ ep.equi.sim <- function(time.its,
   )
 
   L3_vec <- rep(NA, time.its - 1)
+  l3_prev_blackflies <- rep(NA, time.its - 1)
   ABR_recorded <- rep(NA, time.its - 1)
   coverage.recorded <- rep(NA, time.its - 1)
 
@@ -1034,6 +1037,12 @@ ep.equi.sim <- function(time.its,
 
     L3_vec[i] <- mean(all.mats.temp[, 6])
 
+    l3_prev_blackflies[i] <- calculate_l3_prevalence_in_blackflies(
+      l3_per_blackfly = mean(all.mats.temp[, 6]),
+      k0 = k0_in,
+      k1 = k1_in,
+    )
+
     ABR_recorded[i] <- ABR_upd # tracking changing ABR
 
     coverage.recorded[i] <- coverage.upd # track changing coverage if specified
@@ -1155,7 +1164,7 @@ ep.equi.sim <- function(time.its,
     "ov16_seroprevalence_no_seroreversion" = ov16_timetrend_outputs[,"ov16_seroprevalence_no_seroreversion"],
     "ov16_seroprevalence_finite_seroreversion" = ov16_timetrend_outputs[,"ov16_seroprevalence_finite_seroreversion"],
     'L3' = L3_vec, 'ABR' = ABR, 'all_infection_burdens' = all.mats.temp, "Ke" = gam.dis,
-    'years' = mfp_recorded_year_tracker, 'all_mf_prevalence_age_grouped' = mf_prevalence_outputs,
+    'blackfly_l3_prevalence' = l3_prev_blackflies, 'years' = mfp_recorded_year_tracker, 'all_mf_prevalence_age_grouped' = mf_prevalence_outputs,
     'all_mf_intensity_age_grouped' = mf_intensity_outputs, 'ov16_indiv_matrix' = ov16_indiv_matrix,
     "ov16_timetrend_outputs" = ov16_timetrend_outputs, 'ov16_timetrend_outputs_adj' = ov16_timetrend_outputs_adj,
     "worm_burden_outputs" = worm_burden_outputs, 'ABR_recorded' = ABR_recorded, 'coverage.recorded' = coverage.recorded,

--- a/R/Model_wrappers.R
+++ b/R/Model_wrappers.R
@@ -1040,7 +1040,7 @@ ep.equi.sim <- function(time.its,
     l3_prev_blackflies[i] <- calculate_l3_prevalence_in_blackflies(
       l3_per_blackfly = mean(all.mats.temp[, 6]),
       k0 = k0_in,
-      k1 = k1_in,
+      k1 = k1_in
     )
 
     ABR_recorded[i] <- ABR_upd # tracking changing ABR

--- a/R/larval_dynamics_functions.R
+++ b/R/larval_dynamics_functions.R
@@ -89,3 +89,18 @@ calc.L3 <- function(nutwo, L2.in, a.H, g, mu.v, sigma.L0)
   return(out)
 }
 
+#' @title
+#' calculate_l3_prevalence_in_blackflies
+#' @description
+#' Using a typical prevalence-intensity relationship to estimate l3 prevalence in blackflies.
+#'
+#' @param l3_per_blackfly the mean L3 per blackfly
+#' @param k0 parameter defining the y-intercept in the relationship between l3 intensity and overdispersion parameter k
+#' @param k1 parameter defining the slope relationship between l3 intensity and overdispersion parameter k
+#'
+#' @returns vector of mean L3 per individual
+calculate_l3_prevalence_in_blackflies <- function(l3_per_blackfly, k0, k1) {
+  k <- l3_per_blackfly * k1 + k0
+  prevalence <- 1 - (1 + l3_per_blackfly / k)^(-k)
+  return(prevalence)
+}

--- a/vignettes/Running_EPIONCHO_IBM.Rmd
+++ b/vignettes/Running_EPIONCHO_IBM.Rmd
@@ -104,7 +104,7 @@ The output from run_EPIONCHO_IBM is a list with 21 elements.
 names(output_equilibrium)
 ```
 
-The first five elements (`mf_prev`, `mf_intens`, `ov16_seroprevalence_no_seroreversion`, `ov16_seroprevalence_finite_seroreversion` and `L3`) contain the temporal dynamics (at 1 day increments) for the microfilarial prevalence (individuals age > 5), the population mean microfilarial intensity (individuals age > 5), the temporal dynamics for seroprevalence (w/o and w/ seroreverstion), and the mean number of L3 larvae in the black fly population. To plot these over time, use: 
+Within the first 10 elements, there are 5 main outputs (`mf_prev`, `mf_intens`, `ov16_seroprevalence_no_seroreversion`, `ov16_seroprevalence_finite_seroreversion`, `L3`, and `blackfly_l3_prevalence`) which contain the temporal dynamics (at 1 day increments) for the microfilarial prevalence (individuals age > 5), the population mean microfilarial intensity (individuals age > 5), the temporal dynamics for seroprevalence (w/o and w/ seroreverstion), the mean number of L3 larvae in the blackfly population, and the estimated prevalence of l3 in the blackfly population. To plot these over time, use: 
 
 ```{r}
 years <- output_equilibrium$years
@@ -116,7 +116,9 @@ plot(years, output_equilibrium$mf_intens, type = 'l', xlab = 'time (years)', yla
 plot(years, output_equilibrium$ov16_seroprevalence_no_seroreversion, type = 'l', xlab = 'time (years)', ylab = 'seroprevalence w/ no (black) and w/ finite (red) seroreversion', ylim = c(0, 1))
 lines(years, output_equilibrium$ov16_seroprevalence_finite_seroreversion, col="red")
 
-plot(years, output_equilibrium$L3, type = 'l', xlab = 'time (years)', ylab = 'mean L3 in fly population')
+plot(years, output_equilibrium$L3, type = 'l', xlab = 'time (years)', ylab = 'mean L3 in blackfly population')
+
+plot(years, output_equilibrium$blackfly_l3_prevalence, type = 'l', xlab = 'time (years)', ylab = 'L3 prevalence in blackfly population')
 
 # worm burden parameter explained below
 plot(years, output_equilibrium$worm_burden_outputs[, "fertile_female_worm_burden"], type = 'l', xlab = 'time (years)', ylab = 'fertile female worm burden')


### PR DESCRIPTION
- Adding an output for estimated l3 prevalence in blackflies. 
- This is based upon a log-likelihood fitting done with blackfly prevalence and intensity data.
We assume that the relationship between prevalence and intensity is 

_p_ = 1 - (1 + _l_/_k(l)_)^(-_k(l)_)
_k(l)_ = _k0_ + _k1_ x  _l_
_p_ = proportion of infective flies (with O. volvulus L3 larvae)
_l_ = mean no. of L3 larvae per blackfly (using all blackflies, not just parous ones)


Blackfly data used is from Renz (1987) Ann Trop Med Parasitol 81, 239-52  