### PR TITLE
Minor changes to model

### DIFF
--- a/R/Model_wrappers.R
+++ b/R/Model_wrappers.R
@@ -261,10 +261,10 @@ ep.equi.sim <- function(time.its,
 
     #times.of.treat.in <- seq(treat.start, treat.stop - (treat.int / DT), treat.int / DT)
 
-    if(all(!is.na(treat.timing))) {treat.timing <- round(treat.timing / DT) + treat.start} # # 1 day dt
+    if(all(!is.na(treat.timing))) {treat.timing <- ceiling(treat.timing / DT) + treat.start} # # 1 day dt
     if(all(is.na(treat.timing)))
       {times.of.treat.in <- seq(treat.start, treat.stop, treat.int / DT)}
-    else {times.of.treat.in <- treat.timing + (1 / (days_per_year * DT))}
+    else {times.of.treat.in <- treat.timing}
 
     print(paste(length(times.of.treat.in), 'MDA rounds to be given', sep = ' '))
 

--- a/R/Model_wrappers.R
+++ b/R/Model_wrappers.R
@@ -1203,7 +1203,7 @@ ep.equi.sim <- function(time.its,
     'all_mf_intensity_age_grouped' = mf_intensity_outputs, 'ov16_indiv_matrix' = ov16_indiv_matrix,
     "ov16_timetrend_outputs" = ov16_timetrend_outputs, 'ov16_timetrend_outputs_adj' = ov16_timetrend_outputs_adj,
     "worm_burden_outputs" = worm_burden_outputs, 'ABR_recorded' = ABR_recorded, 'coverage.recorded' = coverage.recorded,
-    'percent_never_treated' = never_treated_values
+    'percent_never_treated' = never_treated_values, 'timestep_used' = DT
   )
 
   if (morbidity_module == "YES"){


### PR DESCRIPTION
- Updated the way treat.timing is converted to timesteps so that it always rounds to the ceiling
- Removed `+ (1 / (days_per_year * DT))` when converting treat.timing to times.of.treat.in, as the + is already added when we convert treat.start to timesteps (See [line 135](https://github.com/mrc-ide/EPIONCHO.IBM/compare/small-fixes?expand=1#diff-fd525b688a2999da52d12300396006a3f190d5fa7d817f7c0d12fbe0c5c0d78eR135) of Model_warppers.R).
- Added timestep to the model outputs for use in future post-processing
